### PR TITLE
Update links to Whoosh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Includes:
 	- See `settings.py` for details.
 - Setup script (read contents of script for more information)
 	- Run `virtualenv-setup.sh` to perform an isolated installation.
-- Main controller script 
+- Main controller script
 	- Run `main.py -h` for more information.
 - End-to-end interface
-	- Indexing and searching text (source code). Built-in support for [whoosh](http://packages.python.org/Whoosh) (fast searching) or [xapian](http://xapian.org/) (much faster searching).
+	- Indexing and searching text (source code). Built-in support for [whoosh](https://whoosh.readthedocs.io) (fast searching) or [xapian](http://xapian.org/) (much faster searching).
 	    - Easily extend indexing or searching via custom backends.
 	- Front end web app served using [werkzeug](http://werkzeug.pocoo.org/) or [cherrypy](http://www.cherrypy.org/).
 	    - `werkzeug` is for development to small traffic.
@@ -62,7 +62,7 @@ settings.py
     - Possbile values:
         - `whoosh` the default, no extra work needed.
         - `xapian` must be installed separately using the included `setup/install-xapian.sh` setup script.
-        
+
 ## Using other web servers
 
 settings.py
@@ -77,7 +77,7 @@ settings.py
 
 **Requires Python 2.6 or later.**
 
-* Whoosh - [whoosh](http://packages.python.org/Whoosh/quickstart.html#a-quick-introduction)
+* Whoosh - [whoosh](https://whoosh.readthedocs.io/en/latest/quickstart.html#a-quick-introduction)
 * Flask - [flask](http://flask.pocoo.org)
 * Jinja2 - [jinja2](http://jinja.pocoo.org/docs)
 * Pygments - [pygments](http://pygments.org/docs/quickstart)
@@ -98,5 +98,5 @@ settings.py
 
 1. Provide an easy to setup, fast, and adequate text search engine solution.
 1. Be a respectable alternative to [OpenGrok](https://github.com/OpenGrok/OpenGrok).
-1. Influence the authors of [OpenGrok](https://github.com/OpenGrok/OpenGrok) to provide a simpler setup process. 
+1. Influence the authors of [OpenGrok](https://github.com/OpenGrok/OpenGrok) to provide a simpler setup process.
 	- I successfully setup two installations on CentOS and Ubuntu 11.x and each time it took more than two hours. TS setup takes less than 10 minutes (excluding package download time).

--- a/core/sherlock/backends/whoosh_backend.py
+++ b/core/sherlock/backends/whoosh_backend.py
@@ -5,8 +5,8 @@ Created by Christopher Bess
 Copyright 2011
 
 refs:
-http://packages.python.org/Whoosh/quickstart.html
-http://packages.python.org/Whoosh/indexing.html
+https://whoosh.readthedocs.io/en/latest/quickstart.html
+https://whoosh.readthedocs.io/en/latest/indexing.html
 """
 __author__ = 'C. Bess'
 
@@ -161,7 +161,7 @@ class WhooshResult(SearchResult):
 
 # refs:
 # https://bitbucket.org/mchaput/whoosh/src/4470a8812c9e/src/whoosh/highlight.py
-# http://packages.python.org/Whoosh/api/highlight.html?highlight=hit#manual-highlighting
+# http://whoosh.readthedocs.io/en/latest/api/highlight.html#manual-highlighting
 class ResultFragmenter(highlight.Fragmenter):
     def fragment_tokens(self, text, all_tokens):
         tokens = []


### PR DESCRIPTION
http://packages.python.org/Whoosh just contains a link directing to rtd.