### PR TITLE
Update dependencies

### DIFF
--- a/setup/manual-setup.sh
+++ b/setup/manual-setup.sh
@@ -14,13 +14,13 @@ mkdir -p ../data/indexes
 
 # for the sherlock.webapp
 echo "grabbing flask"
-curl -o flask.zip https://nodeload.github.com/mitsuhiko/flask/zipball/0.7.2
+curl -o flask.zip https://github.com/pallets/flask/archive/0.11.1.zip
 unzip flask.zip
 cp -r mitsuhiko-flask-*/flask ../core
 
 # flask peewee database layer
 echo "grabbing flask-peewee"
-curl -o flask-peewee.tar.gz http://pypi.python.org/packages/source/f/flask-peewee/flask-peewee-0.2.0.tar.gz
+curl -o flask-peewee.tar.gz http://pypi.python.org/packages/source/f/flask-peewee/flask-peewee-0.6.7.tar.gz
 tar -xvzf flask-peewee.tar.gz
 cp -r flask-peewee-*/flaskext ../core
 
@@ -30,32 +30,32 @@ cp ./peewee.py ../core
 
 # flask web server
 echo "grabbing Werkzeug"
-curl -o Werkzeug.tar.gz http://pypi.python.org/packages/source/W/Werkzeug/Werkzeug-0.7.1.tar.gz
+curl -o Werkzeug.tar.gz http://pypi.python.org/packages/source/W/Werkzeug/Werkzeug-0.11.11.tar.gz
 tar -xvzf Werkzeug.tar.gz
 cp -r Werkzeug-*/werkzeug ../core
 
 # cherrypy web server
 echo "grabbing cherrypy"
-curl -o cherrypy.zip http://download.cherrypy.org/cherrypy/3.2.0/CherryPy-3.2.0.zip
+curl -o cherrypy.zip http://download.cherrypy.org/cherrypy/8.1.2/CherryPy-8.1.2.zip
 unzip cherrypy.zip
 cp -r CherryPy*/py2/cherrypy ../core
 
 # required for sherlock.webapp
 echo "grabbing Jinja2"
-curl -o jinja2.tar.gz http://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.5.tar.gz
+curl -o jinja2.tar.gz http://pypi.python.org/packages/source/J/Jinja2/Jinja2-2.8.tar.gz
 tar -xvzf jinja2.tar.gz
 cp -r Jinja2*/jinja2 ../core
 
 # required for the sherlock indexer
 echo "grabbing Whoosh"
-curl -o whoosh.zip http://pypi.python.org/packages/source/W/Whoosh/Whoosh-2.2.2.zip
+curl -o whoosh.zip http://pypi.python.org/packages/source/W/Whoosh/Whoosh-2.5.7.zip
 unzip whoosh.zip
 cp -r Whoosh*/src/whoosh ../core
 
 # dependency for sherlock.transformer
 echo "grabbing Pygments"
 # or the latest: https://bitbucket.org/birkenfeld/pygments-main/get/default.zip
-curl -o pygments.zip https://bitbucket.org/birkenfeld/pygments-main/get/1.4.zip
+curl -o pygments.zip https://bitbucket.org/birkenfeld/pygments-main/get/2.1.3.zip
 unzip pygments.zip
 cp -r *pygments*/src/pygments ../core
 

--- a/setup/requirements.txt
+++ b/setup/requirements.txt
@@ -1,9 +1,9 @@
-flask<=0.9
-whoosh<2.5.0
-jinja2<=2.6
-pygments<=1.5.0
-cherrypy<=3.2.2
-flask-peewee<=0.6.2
-peewee<=2.0.5
+flask>=0.10,<=0.11.1
+whoosh<2.7.0
+jinja2==2.8
+pygments<=2.1.3
+cherrypy>5.0.0,<=8.1.2
+flask-peewee<=0.6.7
+peewee<=2.8.5
 path.py
 pyyaml


### PR DESCRIPTION
Whoosh is available in 2.7.x but [breaks index format compatibility](https://whoosh.readthedocs.io/en/latest/releases/2_0.html#whoosh-2-7).
Note that while whoosh 2.5 can read indices created by older versions the same is not true in reverse.

Maybe I'll check out Xapian later on, too. 